### PR TITLE
Add composer v2 support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ All notable changes to this project will be documented in this file, in reverse 
 
 ### Added
 
-- Nothing.
+- [#9](https://github.com/laminas/laminas-skeleton-installer/pull/9) Added support for composer 2.0
 
 ### Changed
 

--- a/composer.json
+++ b/composer.json
@@ -32,7 +32,7 @@
         "laminas/laminas-zendframework-bridge": "^1.0"
     },
     "require-dev": {
-        "composer/composer": "^1.4.1 || ^2.0@dev",
+        "composer/composer": "^1.5.2 || ~2.0.0.0@dev || ^2.0",
         "laminas/laminas-coding-standard": "~1.0.0",
         "malukenho/docheader": "^0.1.7",
         "mikey179/vfsstream": "^1.6.7",

--- a/composer.json
+++ b/composer.json
@@ -33,7 +33,6 @@
     },
     "require-dev": {
         "composer/composer": "^1.4.1 || ^2.0@dev",
-        "composer/semver": "^1.5.1 || ^2.0@dev",
         "laminas/laminas-coding-standard": "~1.0.0",
         "malukenho/docheader": "^0.1.7",
         "mikey179/vfsstream": "^1.6.7",

--- a/composer.json
+++ b/composer.json
@@ -27,12 +27,13 @@
     },
     "require": {
         "php": "^5.6 || ^7.0",
-        "composer-plugin-api": "^1.0",
+        "composer-plugin-api": "^1.0 || ^2.0",
         "laminas/laminas-component-installer": "^1.0 || ^2.1.2",
         "laminas/laminas-zendframework-bridge": "^1.0"
     },
     "require-dev": {
-        "composer/composer": "^1.4.1",
+        "composer/composer": "^1.4.1 || ^2.0@dev",
+        "composer/semver": "^1.5.1 || ^2.0@dev",
         "laminas/laminas-coding-standard": "~1.0.0",
         "malukenho/docheader": "^0.1.7",
         "mikey179/vfsstream": "^1.6.7",

--- a/test/PluginTest.php
+++ b/test/PluginTest.php
@@ -10,8 +10,11 @@ namespace LaminasTest\SkeletonInstaller;
 
 use Composer\Composer;
 use Composer\IO\IOInterface;
+use Composer\Plugin\PluginInterface;
 use Laminas\SkeletonInstaller\Plugin;
 use PHPUnit\Framework\TestCase;
+use function var_dump;
+use function version_compare;
 
 class PluginTest extends TestCase
 {
@@ -27,8 +30,14 @@ class PluginTest extends TestCase
         $this->assertAttributeSame($io, 'io', $plugin);
     }
 
-    public function testSubscribesToExpectedEvents()
+    public function testSubscribesToExpectedEventsForComposer1()
     {
+        if (! version_compare(PluginInterface::PLUGIN_API_VERSION, '2.0', 'lt')) {
+            $this->markTestSkipped('This test is only needed for composer v1.');
+
+            return;
+        }
+
         $subscribers = Plugin::getSubscribedEvents();
         $this->assertArrayHasKey('post-install-cmd', $subscribers);
         $this->assertArrayHasKey('post-update-cmd', $subscribers);
@@ -36,6 +45,26 @@ class PluginTest extends TestCase
         $expected = [
             ['installOptionalDependencies', 1000],
             ['uninstallPlugin'],
+        ];
+
+        $this->assertEquals($expected, $subscribers['post-install-cmd']);
+        $this->assertEquals($expected, $subscribers['post-update-cmd']);
+    }
+
+    public function testSubscribesToExpectedEventsForComposer2()
+    {
+        if (! version_compare(PluginInterface::PLUGIN_API_VERSION, '2.0.0', 'ge')) {
+            $this->markTestSkipped('This test is only needed for composer v2.');
+
+            return;
+        }
+
+        $subscribers = Plugin::getSubscribedEvents();
+        $this->assertArrayHasKey('post-install-cmd', $subscribers);
+        $this->assertArrayHasKey('post-update-cmd', $subscribers);
+
+        $expected = [
+            ['installOptionalDependencies', 1000],
         ];
 
         $this->assertEquals($expected, $subscribers['post-install-cmd']);

--- a/test/PluginTest.php
+++ b/test/PluginTest.php
@@ -13,7 +13,6 @@ use Composer\IO\IOInterface;
 use Composer\Plugin\PluginInterface;
 use Laminas\SkeletonInstaller\Plugin;
 use PHPUnit\Framework\TestCase;
-use function var_dump;
 use function version_compare;
 
 class PluginTest extends TestCase


### PR DESCRIPTION
|    Q          |   A
|-------------- | ------
| BC Break      | no
| New Feature   | yes

### Description

I've added composer 2.0 support. Not quite sure if we should go with `version_compare` in those parts or if we create own plugins depending on versions?

Any suggestions?