### PR TITLE
Fix errors prompting users when using Composer v2

### DIFF
--- a/src/OptionalPackagesInstaller.php
+++ b/src/OptionalPackagesInstaller.php
@@ -143,9 +143,9 @@ class OptionalPackagesInstaller
      */
     private function requestMinimalInstall()
     {
-        $question = [
-            "\n    <question>Do you want a minimal install (no optional packages)?</question> <comment>Y/n</comment>\n",
-        ];
+        $question =
+            "\n    <question>Do you want a minimal install (no optional packages)?</question> <comment>Y/n</comment>\n"
+        ;
 
         while (true) {
             $answer = $this->io->ask($question, 'y');
@@ -171,10 +171,10 @@ class OptionalPackagesInstaller
      */
     private function promptForPackage(OptionalPackage $package)
     {
-        $question = [sprintf(
+        $question = sprintf(
             "\n    <question>%s</question> <comment>y/N</comment>\n",
             $package->getPrompt()
-        )];
+        );
 
         while (true) {
             $answer = $this->io->ask($question, 'n');

--- a/test/OptionalPackagesInstallerTest.php
+++ b/test/OptionalPackagesInstallerTest.php
@@ -119,13 +119,12 @@ class OptionalPackagesInstallerTest extends TestCase
         ]);
         $this->composer->getPackage()->willReturn($package->reveal());
 
-        $this->io->ask(Argument::that(function ($arg) {
-            if (! is_array($arg)) {
-                return false;
-            }
-            $prompt = array_shift($arg);
-            return (false !== strpos($prompt, 'Do you want a minimal install'));
-        }), 'y')->willReturn('y');
+        $this->io
+            ->ask(
+                Argument::containingString('Do you want a minimal install'),
+                'y'
+            )
+            ->willReturn('y');
         $this->io->write(Argument::containingString('Removing optional packages from composer.json'))->shouldBeCalled();
         $this->io->write(Argument::containingString('Updating composer.json'))->shouldBeCalled();
 
@@ -154,19 +153,14 @@ class OptionalPackagesInstallerTest extends TestCase
         ]);
         $this->composer->getPackage()->willReturn($package->reveal());
 
-        $this->io->ask(Argument::that(function ($arg) {
-            if (! is_array($arg)) {
-                return false;
-            }
-            $prompt = array_shift($arg);
-            return (false !== strpos($prompt, 'Do you want a minimal install'));
-        }), 'y')->willReturn('n');
+        $this->io
+            ->ask(
+                Argument::containingString('Do you want a minimal install'),
+                'y'
+            )
+            ->willReturn('n');
 
-        $this->io->ask(Argument::that(function ($arg) {
-            if (! is_array($arg)) {
-                return false;
-            }
-            $prompt = array_shift($arg);
+        $this->io->ask(Argument::that(function ($prompt) {
             return (false !== strpos($prompt, 'This is a prompt'))
                 && (false !== strpos($prompt, 'y/N'));
         }), 'n')->willReturn('n');
@@ -200,19 +194,14 @@ class OptionalPackagesInstallerTest extends TestCase
         ]);
         $this->composer->getPackage()->willReturn($package->reveal());
 
-        $this->io->ask(Argument::that(function ($arg) {
-            if (! is_array($arg)) {
-                return false;
-            }
-            $prompt = array_shift($arg);
-            return (false !== strpos($prompt, 'Do you want a minimal install'));
-        }), 'y')->willReturn('n');
+        $this->io
+            ->ask(
+                Argument::containingString('Do you want a minimal install'),
+                'y'
+            )
+            ->willReturn('n');
 
-        $this->io->ask(Argument::that(function ($arg) {
-            if (! is_array($arg)) {
-                return false;
-            }
-            $prompt = array_shift($arg);
+        $this->io->ask(Argument::that(function ($prompt) {
             return (false !== strpos($prompt, 'This is a prompt'))
                 && (false !== strpos($prompt, 'y/N'));
         }), 'n')->willReturn('y');
@@ -268,19 +257,14 @@ class OptionalPackagesInstallerTest extends TestCase
         ]);
         $this->composer->getPackage()->willReturn($package->reveal());
 
-        $this->io->ask(Argument::that(function ($arg) {
-            if (! is_array($arg)) {
-                return false;
-            }
-            $prompt = array_shift($arg);
-            return (false !== strpos($prompt, 'Do you want a minimal install'));
-        }), 'y')->willReturn('n');
+        $this->io
+            ->ask(
+                Argument::containingString('Do you want a minimal install'),
+                'y'
+            )
+            ->willReturn('n');
 
-        $this->io->ask(Argument::that(function ($arg) {
-            if (! is_array($arg)) {
-                return false;
-            }
-            $prompt = array_shift($arg);
+        $this->io->ask(Argument::that(function ($prompt) {
             return (false !== strpos($prompt, 'This is a prompt'))
                 && (false !== strpos($prompt, 'y/N'));
         }), 'n')->willReturn('y');


### PR DESCRIPTION
| Q    | A   |
| ---- | --- |
| Bug? | Yes |

Composer v1 allows a string or an array of strings as the first argument to `IOInterface::ask()`. However, Composer v2 does not, and delegates directly to a symfony/console `Question` instance, which requires specifically a string. Since we always passed an array with a single string, it was safe to change these values to strings throughout.

Fixes #14 
