### PR TITLE
Added PHP 8.0 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,32 +12,6 @@ env:
 matrix:
   fast_finish: true
   include:
-    - php: 5.6
-      env:
-        - DEPS=lowest
-    - php: 5.6
-      env:
-        - DEPS=latest
-    - php: 7
-      env:
-        - DEPS=lowest
-    - php: 7
-      env:
-        - DEPS=latest
-    - php: 7.1
-      env:
-        - DEPS=lowest
-    - php: 7.1
-      env:
-        - DEPS=latest
-        - CS_CHECK=true
-        - TEST_COVERAGE=true
-    - php: 7.2
-      env:
-        - DEPS=lowest
-    - php: 7.2
-      env:
-        - DEPS=latest
     - php: 7.3
       env:
         - DEPS=lowest
@@ -48,6 +22,12 @@ matrix:
       env:
         - DEPS=lowest
     - php: 7.4
+      env:
+        - DEPS=latest
+    - php: 8.0
+      env:
+        - DEPS=lowest
+    - php: 8.0
       env:
         - DEPS=latest
 

--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,7 @@
         "class": "Laminas\\SkeletonInstaller\\Plugin"
     },
     "require": {
-        "php": "^5.6 || ^7.0",
+        "php": "^7.3 || ~8.0.0",
         "composer-plugin-api": "^1.0 || ^2.0",
         "laminas/laminas-component-installer": "^1.0 || ^2.1.2",
         "laminas/laminas-zendframework-bridge": "^1.0"
@@ -33,7 +33,8 @@
         "laminas/laminas-coding-standard": "~1.0.0",
         "malukenho/docheader": "^0.1.7",
         "mikey179/vfsstream": "^1.6.7",
-        "phpunit/phpunit": "^5.7.27 || ^6.5.8 || ^7.1.4"
+        "phpspec/prophecy-phpunit": "^2.0",
+        "phpunit/phpunit": "^9.3"
     },
     "autoload": {
         "psr-4": {

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,17 +1,17 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:noNamespaceSchemaLocation="vendor/phpunit/phpunit/phpunit.xsd"
+         xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd"
          bootstrap="vendor/autoload.php"
          colors="true">
-    <testsuites>
-        <testsuite name="laminas-skeleton-installer Tests">
-            <directory>./test</directory>
-        </testsuite>
-    </testsuites>
-
-    <filter>
-        <whitelist processUncoveredFilesFromWhitelist="true">
-            <directory suffix=".php">src</directory>
-        </whitelist>
-    </filter>
+  <testsuites>
+    <testsuite name="laminas-skeleton-installer Tests">
+      <directory>./test</directory>
+    </testsuite>
+  </testsuites>
+  
+  <coverage processUncoveredFiles="true">
+    <include>
+      <directory suffix=".php">src</directory>
+    </include>
+  </coverage>
 </phpunit>

--- a/src/OptionalPackagesInstaller.php
+++ b/src/OptionalPackagesInstaller.php
@@ -318,7 +318,7 @@ class OptionalPackagesInstaller
         );
 
         $installer->setDevMode(true);
-        $installer->setUpdate();
+        $installer->setUpdate(true);
 
         $this->attachPackageWhitelistBasedOnComposerVersion($installer, $packagesToInstall);
 

--- a/test/BroadcastEventDispatcherTest.php
+++ b/test/BroadcastEventDispatcherTest.php
@@ -12,17 +12,20 @@ use Composer\Composer;
 use Composer\IO\IOInterface;
 use Laminas\SkeletonInstaller\BroadcastEventDispatcher;
 use PHPUnit\Framework\TestCase;
+use Prophecy\PhpUnit\ProphecyTrait;
 use Prophecy\Prophecy\ObjectProphecy;
 
 class BroadcastEventDispatcherTest extends TestCase
 {
+    use ProphecyTrait;
+
     /** @var Composer|ObjectProphecy */
     private $composer;
 
     /** @var IOInterface|ObjectProphecy */
     private $io;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         parent::setUp();
 

--- a/test/OptionalPackagesInstallerTest.php
+++ b/test/OptionalPackagesInstallerTest.php
@@ -17,6 +17,7 @@ use Composer\Plugin\PluginInterface;
 use org\bovigo\vfs\vfsStream;
 use PHPUnit\Framework\TestCase;
 use Prophecy\Argument;
+use Prophecy\PhpUnit\ProphecyTrait;
 use Prophecy\Prophecy\ObjectProphecy;
 use Prophecy\Prophecy\ProphecyInterface;
 use ReflectionProperty;
@@ -24,6 +25,8 @@ use function version_compare;
 
 class OptionalPackagesInstallerTest extends TestCase
 {
+    use ProphecyTrait;
+
     /** @var Composer|ProphecyInterface */
     private $composer;
 
@@ -33,7 +36,7 @@ class OptionalPackagesInstallerTest extends TestCase
     /** @var OptionalPackagesInstaller|ProphecyInterface */
     private $installer;
 
-    public function setUp()
+    public function setUp(): void
     {
         $this->composer = $this->prophesize(Composer::class);
         $this->io = $this->prophesize(IOInterface::class);
@@ -80,7 +83,7 @@ class OptionalPackagesInstallerTest extends TestCase
     {
         $installer = $this->prophesize(Installer::class);
         $installer->setDevMode(true)->shouldBeCalled();
-        $installer->setUpdate()->shouldBeCalled();
+        $installer->setUpdate(true)->shouldBeCalled();
 
         $this->addExpectedPackagesAssertionBasedOnComposerVersion($installer, $expectedPackages);
         $installer->run()->willReturn($expectedReturn);

--- a/test/PluginTest.php
+++ b/test/PluginTest.php
@@ -13,10 +13,14 @@ use Composer\IO\IOInterface;
 use Composer\Plugin\PluginInterface;
 use Laminas\SkeletonInstaller\Plugin;
 use PHPUnit\Framework\TestCase;
+use Prophecy\PhpUnit\ProphecyTrait;
+use ReflectionProperty;
 use function version_compare;
 
 class PluginTest extends TestCase
 {
+    use ProphecyTrait;
+
     public function testActivateSetsComposerAndIoProperties()
     {
         $composer = $this->prophesize(Composer::class)->reveal();
@@ -25,8 +29,16 @@ class PluginTest extends TestCase
         $plugin = new Plugin();
         $plugin->activate($composer, $io);
 
-        $this->assertAttributeSame($composer, 'composer', $plugin);
-        $this->assertAttributeSame($io, 'io', $plugin);
+        $rComposer = new ReflectionProperty($plugin, 'composer');
+        $rComposer->setAccessible(true);
+
+        $this->assertSame($composer, $rComposer->getValue($plugin));
+
+        
+        $rIo = new ReflectionProperty($plugin, 'io');
+        $rIo->setAccessible(true);
+
+        $this->assertSame($io, $rIo->getValue($plugin));
     }
 
     public function testSubscribesToExpectedEventsForComposer1()

--- a/test/UninstallerTest.php
+++ b/test/UninstallerTest.php
@@ -15,24 +15,27 @@ use Composer\IO\IOInterface;
 use Composer\Package\AliasPackage;
 use Composer\Package\Locker;
 use Composer\Package\PackageInterface;
-use Composer\Repository\RepositoryInterface;
+use Composer\Repository\InstalledRepositoryInterface;
 use Composer\Repository\RepositoryManager;
 use Laminas\SkeletonInstaller\Uninstaller;
 use org\bovigo\vfs\vfsStream;
 use PHPUnit\Framework\TestCase;
 use Prophecy\Argument;
+use Prophecy\PhpUnit\ProphecyTrait;
 use Prophecy\Prophecy\ProphecyInterface;
 use ReflectionProperty;
 
 class UninstallerTest extends TestCase
 {
+    use ProphecyTrait;
+
     /** @var IOInterface|ProphecyInterface */
     private $io;
 
     /** @var Composer|ProphecyInterface */
     private $composer;
 
-    public function setUp()
+    public function setUp(): void
     {
         $this->io = $this->setUpIo();
         $this->composer = $this->setUpComposerAndDependencies();
@@ -101,7 +104,7 @@ class UninstallerTest extends TestCase
         $composer = $this->prophesize(Composer::class);
 
         $package = $this->prophesize(PackageInterface::class);
-        $repository = $this->prophesize(RepositoryInterface::class);
+        $repository = $this->prophesize(InstalledRepositoryInterface::class);
         $repository->findPackage(Uninstaller::PLUGIN_NAME, '*')->willReturn($package->reveal());
         $repository->getPackages()->willReturn([]);
 


### PR DESCRIPTION
|    Q          |   A
|-------------- | ------
| Documentation | no
| Bugfix        | no
| BC Break      | yes
| New Feature   | yes
| RFC           | no
| QA            | no

### Description

Added PHP 8.0 support

- Added PHP 8.0 constraint to composer.json
- Removed PHP less 7.3 support from composer.json
- Modified composer.json to implement phpunit 9.3
- Fixed phpunit tests and config to be compatible with the phpunit 9.3
- Added PHP 8.0 to .travis.yml
- Removed PHP less 7.3 support from .travis.yml
