### PR TITLE
Forward compat for Composer 2.3+

### DIFF
--- a/src/BroadcastEventDispatcher.php
+++ b/src/BroadcastEventDispatcher.php
@@ -40,7 +40,7 @@ class BroadcastEventDispatcher extends EventDispatcher
     /**
      * @inheritDoc
      */
-    protected function doDispatch(Event $event)
+    protected function doDispatch(Event $event): int
     {
         if ($this->eventDispatcher && in_array($event->getName(), $this->broadcastEvents, true)) {
             return $this->eventDispatcher->doDispatch($event);


### PR DESCRIPTION
We're adding return types in Composer and would rather avoid breaking dependents. I skipped this method for now because of this project but it'd be nice if you do add it anyway so we can add it at some future point.