### PR TITLE
Fix type incompatiblity with `Composer\IO\IOInterface::ask()`

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,6 +20,9 @@
         "sort-packages": true,
         "platform": {
             "php": "7.3.99"
+        },
+        "allow-plugins": {
+            "dealerdirect/phpcodesniffer-composer-installer": true
         }
     },
     "extra": {

--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,8 @@
             "php": "7.3.99"
         },
         "allow-plugins": {
-            "dealerdirect/phpcodesniffer-composer-installer": true
+            "dealerdirect/phpcodesniffer-composer-installer": true,
+            "laminas/laminas-component-installer": false
         }
     },
     "extra": {

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<files psalm-version="4.13.1@5cf660f63b548ccd4a56f62d916ee4d6028e01a3">
+<files psalm-version="v4.15.0@a1b5e489e6fcebe40cb804793d964e99fc347820">
   <file src="src/Collection.php">
     <DocblockTypeContradiction occurrences="2">
       <code>is_array($items)</code>
@@ -56,15 +56,9 @@
     </MixedAssignment>
   </file>
   <file src="src/OptionalPackagesInstaller.php">
-    <InvalidArgument occurrences="3">
+    <InvalidArgument occurrences="1">
       <code>$package</code>
-      <code>$question</code>
-      <code>$question</code>
     </InvalidArgument>
-    <InvalidCast occurrences="2">
-      <code>$question</code>
-      <code>$question</code>
-    </InvalidCast>
     <MissingClosureParamType occurrences="8">
       <code>$composer</code>
       <code>$package</code>
@@ -265,32 +259,7 @@
     </MixedInferredReturnType>
   </file>
   <file src="test/OptionalPackagesInstallerTest.php">
-    <ImplicitToStringCast occurrences="25">
-      <code>Argument::any()</code>
-      <code>Argument::containingString('Error installing optional packages')</code>
-      <code>Argument::containingString('No optional packages selected')</code>
-      <code>Argument::containingString('No optional packages selected')</code>
-      <code>Argument::containingString('No optional packages selected')</code>
-      <code>Argument::containingString('Removing optional packages from composer.json')</code>
-      <code>Argument::containingString('Removing optional packages from composer.json')</code>
-      <code>Argument::containingString('Running an update to install optional packages')</code>
-      <code>Argument::containingString('Running an update to install optional packages')</code>
-      <code>Argument::containingString('Updating composer.json')</code>
-      <code>Argument::containingString('Updating composer.json')</code>
-      <code>Argument::containingString('Updating composer.json')</code>
-      <code>Argument::containingString('Updating root package')</code>
-      <code>Argument::containingString('Updating root package')</code>
-      <code>Argument::containingString('Will install laminas/laminas-db')</code>
-      <code>Argument::containingString('Will install laminas/laminas-db')</code>
-    </ImplicitToStringCast>
-    <InvalidFunctionCall occurrences="5">
-      <code>$installer()</code>
-      <code>$installer()</code>
-      <code>$installer()</code>
-      <code>$installer()</code>
-      <code>$installer()</code>
-    </InvalidFunctionCall>
-    <MissingClosureParamType occurrences="9">
+    <MissingClosureParamType occurrences="2">
       <code>$arg</code>
       <code>$arg</code>
       <code>$arg</code>
@@ -306,96 +275,13 @@
       <code>testAddingAnOptionalPackageAddsItToComposerAndUpdatesAppConfig</code>
       <code>testInstallerFailureShouldLeaveOptionalPackagesIntact</code>
     </MissingReturnType>
-    <MixedArgument occurrences="10">
-      <code>$prompt</code>
-      <code>$prompt</code>
-      <code>$prompt</code>
-      <code>$prompt</code>
-      <code>$prompt</code>
-      <code>$prompt</code>
-      <code>$prompt</code>
-      <code>$prompt</code>
-      <code>$prompt</code>
-      <code>$prompt</code>
-    </MixedArgument>
-    <MixedAssignment occurrences="9">
+    <MixedAssignment occurrences="2">
       <code>$composer</code>
       <code>$composer</code>
-      <code>$prompt</code>
-      <code>$prompt</code>
-      <code>$prompt</code>
-      <code>$prompt</code>
-      <code>$prompt</code>
-      <code>$prompt</code>
-      <code>$prompt</code>
     </MixedAssignment>
     <MixedInferredReturnType occurrences="1">
       <code>string</code>
     </MixedInferredReturnType>
-    <MixedMethodCall occurrences="30">
-      <code>shouldBeCalled</code>
-      <code>shouldBeCalled</code>
-      <code>shouldBeCalled</code>
-      <code>shouldBeCalled</code>
-      <code>shouldBeCalled</code>
-      <code>shouldBeCalled</code>
-      <code>shouldBeCalled</code>
-      <code>shouldBeCalled</code>
-      <code>shouldBeCalled</code>
-      <code>shouldBeCalled</code>
-      <code>shouldBeCalled</code>
-      <code>shouldBeCalled</code>
-      <code>shouldBeCalled</code>
-      <code>shouldBeCalled</code>
-      <code>shouldBeCalled</code>
-      <code>shouldNotBeCalled</code>
-      <code>shouldNotBeCalled</code>
-      <code>shouldNotBeCalled</code>
-      <code>willReturn</code>
-      <code>willReturn</code>
-      <code>willReturn</code>
-      <code>willReturn</code>
-      <code>willReturn</code>
-      <code>willReturn</code>
-      <code>willReturn</code>
-      <code>willReturn</code>
-      <code>willReturn</code>
-      <code>willReturn</code>
-      <code>willReturn</code>
-      <code>willReturn</code>
-    </MixedMethodCall>
-    <PossiblyUndefinedMethod occurrences="30">
-      <code>ask</code>
-      <code>ask</code>
-      <code>ask</code>
-      <code>ask</code>
-      <code>ask</code>
-      <code>ask</code>
-      <code>ask</code>
-      <code>getPackage</code>
-      <code>getPackage</code>
-      <code>getPackage</code>
-      <code>getPackage</code>
-      <code>getPackage</code>
-      <code>write</code>
-      <code>write</code>
-      <code>write</code>
-      <code>write</code>
-      <code>write</code>
-      <code>write</code>
-      <code>write</code>
-      <code>write</code>
-      <code>write</code>
-      <code>write</code>
-      <code>write</code>
-      <code>write</code>
-      <code>write</code>
-      <code>write</code>
-      <code>write</code>
-      <code>write</code>
-      <code>write</code>
-      <code>write</code>
-    </PossiblyUndefinedMethod>
     <UndefinedDocblockClass occurrences="2">
       <code>any</code>
       <code>any</code>

--- a/src/OptionalPackagesInstaller.php
+++ b/src/OptionalPackagesInstaller.php
@@ -131,13 +131,11 @@ class OptionalPackagesInstaller
      */
     private function requestMinimalInstall()
     {
-        $question = [
-            <<<'END'
+        $question = <<<'END'
 
                 <question>Do you want a minimal install (no optional packages)?</question> <comment>Y/n</comment>
 
-            END,
-        ];
+        END;
 
         while (true) {
             $answer = $this->io->ask($question, 'y');
@@ -162,12 +160,10 @@ class OptionalPackagesInstaller
      */
     private function promptForPackage(OptionalPackage $package)
     {
-        $question = [
-            sprintf(
-                "\n    <question>%s</question> <comment>y/N</comment>\n",
-                $package->getPrompt()
-            ),
-        ];
+        $question = sprintf(
+            "\n    <question>%s</question> <comment>y/N</comment>\n",
+            $package->getPrompt()
+        );
 
         while (true) {
             $answer = $this->io->ask($question, 'n');

--- a/test/OptionalPackagesInstallerTest.php
+++ b/test/OptionalPackagesInstallerTest.php
@@ -20,25 +20,29 @@ use Prophecy\Prophecy\ProphecyInterface;
 use ReflectionProperty;
 
 use function array_key_exists;
-use function array_shift;
 use function file_get_contents;
 use function is_array;
 use function json_decode;
 use function json_encode;
-use function strpos;
 use function version_compare;
 
 class OptionalPackagesInstallerTest extends TestCase
 {
     use ProphecyTrait;
 
-    /** @var Composer|ProphecyInterface */
+    /**
+     * @psalm-var ObjectProphecy<Composer>
+     * @var Composer|ProphecyInterface
+     */
     private $composer;
 
-    /** @var IOInterface|ProphecyInterface */
+    /**
+     * @psalm-var ObjectProphecy<IOInterface>
+     * @var IOInterface|ProphecyInterface
+     */
     private $io;
 
-    /** @var OptionalPackagesInstaller|ProphecyInterface */
+    /** @var OptionalPackagesInstaller */
     private $installer;
 
     public function setUp(): void
@@ -137,13 +141,9 @@ class OptionalPackagesInstallerTest extends TestCase
         ]);
         $this->composer->getPackage()->willReturn($package->reveal());
 
-        $this->io->ask(Argument::that(function ($arg) {
-            if (! is_array($arg)) {
-                return false;
-            }
-            $prompt = array_shift($arg);
-            return false !== strpos($prompt, 'Do you want a minimal install');
-        }), 'y')->willReturn('y');
+        $this->io->ask(Argument::containingString('Do you want a minimal install'), 'y')
+            ->shouldBeCalled()
+            ->willReturn('y');
         $this->io->write(Argument::containingString('Removing optional packages from composer.json'))->shouldBeCalled();
         $this->io->write(Argument::containingString('Updating composer.json'))->shouldBeCalled();
 
@@ -172,22 +172,16 @@ class OptionalPackagesInstallerTest extends TestCase
         ]);
         $this->composer->getPackage()->willReturn($package->reveal());
 
-        $this->io->ask(Argument::that(function ($arg) {
-            if (! is_array($arg)) {
-                return false;
-            }
-            $prompt = array_shift($arg);
-            return false !== strpos($prompt, 'Do you want a minimal install');
-        }), 'y')->willReturn('n');
+        $this->io->ask(Argument::containingString('Do you want a minimal install'), 'y')
+            ->shouldBeCalled()
+            ->willReturn('n');
 
-        $this->io->ask(Argument::that(function ($arg) {
-            if (! is_array($arg)) {
-                return false;
-            }
-            $prompt = array_shift($arg);
-            return (false !== strpos($prompt, 'This is a prompt'))
-                && (false !== strpos($prompt, 'y/N'));
-        }), 'n')->willReturn('n');
+        $this->io->ask(
+            Argument::allOf(Argument::containingString('This is a prompt'), Argument::containingString('y/N')),
+            Argument::any()
+        )
+            ->shouldBeCalled()
+            ->willReturn('n');
 
         $this->io->write(Argument::containingString('No optional packages selected'))->shouldBeCalled();
         $this->io->write(Argument::containingString('Removing optional packages from composer.json'))->shouldBeCalled();
@@ -218,22 +212,16 @@ class OptionalPackagesInstallerTest extends TestCase
         ]);
         $this->composer->getPackage()->willReturn($package->reveal());
 
-        $this->io->ask(Argument::that(function ($arg) {
-            if (! is_array($arg)) {
-                return false;
-            }
-            $prompt = array_shift($arg);
-            return false !== strpos($prompt, 'Do you want a minimal install');
-        }), 'y')->willReturn('n');
+        $this->io->ask(Argument::containingString('Do you want a minimal install'), 'y')
+            ->shouldBeCalled()
+            ->willReturn('n');
 
-        $this->io->ask(Argument::that(function ($arg) {
-            if (! is_array($arg)) {
-                return false;
-            }
-            $prompt = array_shift($arg);
-            return (false !== strpos($prompt, 'This is a prompt'))
-                && (false !== strpos($prompt, 'y/N'));
-        }), 'n')->willReturn('y');
+        $this->io->ask(
+            Argument::allOf(Argument::containingString('This is a prompt'), Argument::containingString('y/N')),
+            Argument::any()
+        )
+            ->shouldBeCalled()
+            ->willReturn('y');
 
         $this->io->write(Argument::containingString('Will install laminas/laminas-db'))->shouldBeCalled();
         $this->io->write(Argument::containingString(
@@ -286,22 +274,16 @@ class OptionalPackagesInstallerTest extends TestCase
         ]);
         $this->composer->getPackage()->willReturn($package->reveal());
 
-        $this->io->ask(Argument::that(function ($arg) {
-            if (! is_array($arg)) {
-                return false;
-            }
-            $prompt = array_shift($arg);
-            return false !== strpos($prompt, 'Do you want a minimal install');
-        }), 'y')->willReturn('n');
+        $this->io->ask(Argument::containingString('Do you want a minimal install'), 'y')
+            ->shouldBeCalled()
+            ->willReturn('n');
 
-        $this->io->ask(Argument::that(function ($arg) {
-            if (! is_array($arg)) {
-                return false;
-            }
-            $prompt = array_shift($arg);
-            return (false !== strpos($prompt, 'This is a prompt'))
-                && (false !== strpos($prompt, 'y/N'));
-        }), 'n')->willReturn('y');
+        $this->io->ask(
+            Argument::allOf(Argument::containingString('This is a prompt'), Argument::containingString('y/N')),
+            Argument::any()
+        )
+            ->shouldBeCalled()
+            ->willReturn('y');
 
         $this->io->write(Argument::containingString('Will install laminas/laminas-db'))->shouldBeCalled();
         $this->io->write(Argument::containingString(

--- a/test/OptionalPackagesInstallerTest.php
+++ b/test/OptionalPackagesInstallerTest.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Laminas\SkeletonInstaller;
+namespace LaminasTest\SkeletonInstaller;
 
 use Composer\Composer;
 use Composer\Installer;
@@ -10,6 +10,7 @@ use Composer\IO\IOInterface;
 use Composer\Package\Link;
 use Composer\Package\RootPackageInterface;
 use Composer\Plugin\PluginInterface;
+use Laminas\SkeletonInstaller\OptionalPackagesInstaller;
 use org\bovigo\vfs\vfsStream;
 use PHPUnit\Framework\TestCase;
 use Prophecy\Argument;


### PR DESCRIPTION
|    Q          |   A
|-------------- | ------
| Documentation | no
| Bugfix        | yes
| BC Break      | no
| New Feature   | no
| RFC           | no
| QA            | no

### Description

This component uses `Composer\IO\IOInterface::ask()` for interactive
installation of packages and passes the question as an array to the `ask()` as
the typehint for the method allowed it before.

While it happened to work with underlying Symfony Console component until
recently it does not appear to have been a supported case. Phpdoc typehint for
Question constructor was `string` going back to at least Symfony 2.5. Newer
Symfony releases utilize native php typhint which results in TypeError.

See https://github.com/composer/composer/issues/7199

Since this change converges with the years old stable interface, no BC break is introduced here.

Fixes #31 
