### PR TITLE
Drop conditional code for composer v1 plugin api

### DIFF
--- a/src/OptionalPackagesInstaller.php
+++ b/src/OptionalPackagesInstaller.php
@@ -10,12 +10,10 @@ use Composer\IO\IOInterface;
 use Composer\Package\Link;
 use Composer\Package\RootPackageInterface;
 use Composer\Package\Version\VersionParser;
-use Composer\Plugin\PluginInterface;
 
 use function is_array;
 use function sprintf;
 use function strtolower;
-use function version_compare;
 
 /**
  * Prompt for and install optional packages.
@@ -337,18 +335,6 @@ class OptionalPackagesInstaller
         ComposerInstaller $installer,
         Collection $packagesToInstall
     ) {
-        // Composer v1.0 support
-        if (version_compare(PluginInterface::PLUGIN_API_VERSION, '2.0', 'lt')) {
-            $installer->setUpdateWhitelist(
-                $packagesToInstall->map(function ($package) {
-                    return $package->getName();
-                })
-                    ->toArray()
-            );
-
-            return;
-        }
-
         $installer->setUpdateAllowList(
             $packagesToInstall->map(function ($package) {
                 return $package->getName();

--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -10,8 +10,6 @@ use Composer\IO\IOInterface;
 use Composer\Plugin\PluginInterface;
 use Composer\Script\Event as ScriptEvent;
 
-use function version_compare;
-
 /**
  * Plugin that uninstalls itself following a create-project operation.
  */
@@ -43,10 +41,6 @@ class Plugin implements PluginInterface, EventSubscriberInterface
         $subscribers = [
             ['installOptionalDependencies', 1000],
         ];
-
-        if (version_compare(PluginInterface::PLUGIN_API_VERSION, '2.0', 'lt')) {
-            $subscribers[] = ['uninstallPlugin'];
-        }
 
         return [
             'post-install-cmd' => $subscribers,

--- a/test/OptionalPackagesInstallerTest.php
+++ b/test/OptionalPackagesInstallerTest.php
@@ -9,7 +9,6 @@ use Composer\Installer;
 use Composer\IO\IOInterface;
 use Composer\Package\Link;
 use Composer\Package\RootPackageInterface;
-use Composer\Plugin\PluginInterface;
 use Laminas\SkeletonInstaller\OptionalPackagesInstaller;
 use org\bovigo\vfs\vfsStream;
 use PHPUnit\Framework\TestCase;
@@ -24,7 +23,6 @@ use function file_get_contents;
 use function is_array;
 use function json_decode;
 use function json_encode;
-use function version_compare;
 
 class OptionalPackagesInstallerTest extends TestCase
 {
@@ -104,7 +102,7 @@ class OptionalPackagesInstallerTest extends TestCase
         $installer->setDevMode(true)->shouldBeCalled();
         $installer->setUpdate(true)->shouldBeCalled();
 
-        $this->addExpectedPackagesAssertionBasedOnComposerVersion($installer, $expectedPackages);
+        $installer->setUpdateAllowList($expectedPackages)->shouldBeCalled();
         $installer->run()->willReturn($expectedReturn);
 
         $r = new ReflectionProperty($this->installer, 'installerFactory');
@@ -320,22 +318,5 @@ class OptionalPackagesInstallerTest extends TestCase
 
         $installer = $this->installer;
         $this->assertNull($installer());
-    }
-
-    /**
-     * @param ObjectProphecy<Installer> $installer
-     */
-    private function addExpectedPackagesAssertionBasedOnComposerVersion(
-        ObjectProphecy $installer,
-        array $expectedPackages
-    ) {
-        // Composer v1.0 support
-        if (version_compare(PluginInterface::PLUGIN_API_VERSION, '2.0', 'lt')) {
-            $installer->setUpdateWhitelist($expectedPackages)->shouldBeCalled();
-
-            return;
-        }
-
-        $installer->setUpdateAllowList($expectedPackages)->shouldBeCalled();
     }
 }

--- a/test/PluginTest.php
+++ b/test/PluginTest.php
@@ -6,13 +6,10 @@ namespace LaminasTest\SkeletonInstaller;
 
 use Composer\Composer;
 use Composer\IO\IOInterface;
-use Composer\Plugin\PluginInterface;
 use Laminas\SkeletonInstaller\Plugin;
 use PHPUnit\Framework\TestCase;
 use Prophecy\PhpUnit\ProphecyTrait;
 use ReflectionProperty;
-
-use function version_compare;
 
 class PluginTest extends TestCase
 {
@@ -37,35 +34,8 @@ class PluginTest extends TestCase
         $this->assertSame($io, $rIo->getValue($plugin));
     }
 
-    public function testSubscribesToExpectedEventsForComposer1()
-    {
-        if (! version_compare(PluginInterface::PLUGIN_API_VERSION, '2.0', 'lt')) {
-            $this->markTestSkipped('This test is only needed for composer v1.');
-
-            return;
-        }
-
-        $subscribers = Plugin::getSubscribedEvents();
-        $this->assertArrayHasKey('post-install-cmd', $subscribers);
-        $this->assertArrayHasKey('post-update-cmd', $subscribers);
-
-        $expected = [
-            ['installOptionalDependencies', 1000],
-            ['uninstallPlugin'],
-        ];
-
-        $this->assertEquals($expected, $subscribers['post-install-cmd']);
-        $this->assertEquals($expected, $subscribers['post-update-cmd']);
-    }
-
     public function testSubscribesToExpectedEventsForComposer2()
     {
-        if (! version_compare(PluginInterface::PLUGIN_API_VERSION, '2.0.0', 'ge')) {
-            $this->markTestSkipped('This test is only needed for composer v2.');
-
-            return;
-        }
-
         $subscribers = Plugin::getSubscribedEvents();
         $this->assertArrayHasKey('post-install-cmd', $subscribers);
         $this->assertArrayHasKey('post-update-cmd', $subscribers);


### PR DESCRIPTION
|    Q          |   A
|-------------- | ------
| Documentation | no
| Bugfix        | no
| BC Break      | no
| New Feature   | no
| RFC           | no
| QA            | yes

### Description

Drop checks for composer v1 plugin api and conditional code. Support for composer v1 was dropped in  #40 

